### PR TITLE
Fix partition tab leader tracking and status visualization

### DIFF
--- a/frontend/src/components/pages/topics/Tab.Partitions.tsx
+++ b/frontend/src/components/pages/topics/Tab.Partitions.tsx
@@ -70,7 +70,7 @@ export class TopicPartitions extends Component<{ topic: Topic }> {
                 },
                 {
                     title: 'Brokers',
-                    render: (v, r) => r.replicas && <BrokerList brokerIds={r.replicas} leaderId={r.replicas.length > 0 ? r.replicas[0] : -1} />
+                    render: (v, r) => <BrokerList partition={r} />
                 }
             ]} />
 


### PR DESCRIPTION
The partitions tab in the topics page is meant to show the
current Leader as well as all the replica brokers of a given partition.

The responsible component so far always picked the first broker in
the replica set as the Leader.

This is usually correct, on partition creation the first broker in the replica
set is denoted as Leader, this broker is the "preferred Leader" for the
given partition and the cluster (depending on the configuration) tends to
re-elect the preferred Leader.

Unfortunately, the preferred Leader is not always available,
it can be the case that that the preferred broker is offline and another
broker is elected as Leader.

The current implementation does not properly track the actual leader,
instead it shows the preferred Leader. It also doesn't show which
brokers are currently online. These issues together can lead to very
confusing visualization scenarios where the offline preferred Leader is shown as
the online current Leader while a different broker is the actual Leader.

@rikimaru0345  on commit cc46b25673b507f19d8143bcb8d586f7ecdaf6af
added better tracking support in the
`/pages/reassign-partitions/components/BrokerList.tsx`
component which not only properly tracks the Leader but also
shows the online/offline status of the brokers containing
the replicas. Unfortunately it seems that the augmented `partition`
property enabling these semantics was never actually used.

This commit replaces the naive manual passing of the `leaderId` and `brokerIds` properties to
the `BrokerList` component with the passing of the augmented `partition` property.