### PR TITLE
Use config vars instead of hardcoded timeouts

### DIFF
--- a/backend/pkg/api/handle_kafka_connect.go
+++ b/backend/pkg/api/handle_kafka_connect.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"time"
 
 	con "github.com/cloudhut/connect-client"
 	"github.com/cloudhut/kowl/backend/pkg/connect"
@@ -32,7 +31,7 @@ func (api *API) handleGetConnectors() http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
+		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
 
 		connectors, err := api.ConnectSvc.GetAllClusterConnectors(ctx)
@@ -75,7 +74,7 @@ func (api *API) handleGetClusterConnectors() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		clusterName := chi.URLParam(r, "clusterName")
 
-		ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
+		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
 
 		canSee, restErr := api.Hooks.Owl.CanViewConnectCluster(r.Context(), clusterName)
@@ -139,7 +138,7 @@ func (api *API) handleGetConnector() http.HandlerFunc {
 		clusterName := chi.URLParam(r, "clusterName")
 		connector := chi.URLParam(r, "connector")
 
-		ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
+		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
 
 		canSee, restErr := api.Hooks.Owl.CanViewConnectCluster(r.Context(), clusterName)
@@ -318,7 +317,7 @@ func (api *API) handleDeleteConnector() http.HandlerFunc {
 		clusterName := chi.URLParam(r, "clusterName")
 		connector := chi.URLParam(r, "connector")
 
-		ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
+		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
 
 		canDelete, restErr := api.Hooks.Owl.CanDeleteConnectCluster(r.Context(), clusterName)
@@ -352,7 +351,7 @@ func (api *API) handlePauseConnector() http.HandlerFunc {
 		clusterName := chi.URLParam(r, "clusterName")
 		connector := chi.URLParam(r, "connector")
 
-		ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
+		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
 
 		canEdit, restErr := api.Hooks.Owl.CanEditConnectCluster(r.Context(), clusterName)
@@ -386,7 +385,7 @@ func (api *API) handleResumeConnector() http.HandlerFunc {
 		clusterName := chi.URLParam(r, "clusterName")
 		connector := chi.URLParam(r, "connector")
 
-		ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
+		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
 
 		canEdit, restErr := api.Hooks.Owl.CanEditConnectCluster(r.Context(), clusterName)
@@ -420,7 +419,7 @@ func (api *API) handleRestartConnector() http.HandlerFunc {
 		clusterName := chi.URLParam(r, "clusterName")
 		connector := chi.URLParam(r, "connector")
 
-		ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
+		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
 
 		canEdit, restErr := api.Hooks.Owl.CanEditConnectCluster(r.Context(), clusterName)
@@ -465,7 +464,7 @@ func (api *API) handleRestartConnectorTask() http.HandlerFunc {
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
+		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
 
 		canEdit, restErr := api.Hooks.Owl.CanEditConnectCluster(r.Context(), clusterName)

--- a/backend/pkg/connect/config.go
+++ b/backend/pkg/connect/config.go
@@ -22,9 +22,9 @@ const (
 )
 
 type Config struct {
-	ConnectTimeout time.Duration   `yaml:"connect_timeout"` // used for connectivity test
-	ReadTimeout    time.Duration   `yaml:"read_timeout"`    // overall REST/HTTP read timeout
-	RequestTimeout time.Duration   `yaml:"request_timeout"` // timeout for REST requests to Kafka Connect
+	ConnectTimeout time.Duration   `yaml:"connectTimeout"` // used for connectivity test
+	ReadTimeout    time.Duration   `yaml:"readTimeout"`    // overall REST/HTTP read timeout
+	RequestTimeout time.Duration   `yaml:"requestTimeout"` // timeout for REST requests to Kafka Connect
 	Enabled        bool            `yaml:"enabled"`
 	Clusters       []ConfigCluster `yaml:"clusters"`
 }

--- a/backend/pkg/connect/config.go
+++ b/backend/pkg/connect/config.go
@@ -12,17 +12,30 @@ package connect
 import (
 	"flag"
 	"fmt"
+	"time"
+)
+
+const (
+	defaultConnectTimeout = 15 * time.Second
+	defaultReadTimeout    = 60 * time.Second
+	defaultRequestTimeout = 6 * time.Second
 )
 
 type Config struct {
-	Enabled  bool            `yaml:"enabled"`
-	Clusters []ConfigCluster `yaml:"clusters"`
+	ConnectTimeout time.Duration   `yaml:"connect_timeout"` // used for connectivity test
+	ReadTimeout    time.Duration   `yaml:"read_timeout"`    // overall REST/HTTP read timeout
+	RequestTimeout time.Duration   `yaml:"request_timeout"` // timeout for REST requests to Kafka Connect
+	Enabled        bool            `yaml:"enabled"`
+	Clusters       []ConfigCluster `yaml:"clusters"`
 }
 
 func (c *Config) SetDefaults() {
 	for _, cluster := range c.Clusters {
 		cluster.SetDefaults()
 	}
+	c.ConnectTimeout = defaultConnectTimeout
+	c.ReadTimeout = defaultReadTimeout
+	c.RequestTimeout = defaultRequestTimeout
 }
 
 // RegisterFlags registers all nested config flags.

--- a/backend/pkg/connect/config.go
+++ b/backend/pkg/connect/config.go
@@ -15,27 +15,21 @@ import (
 	"time"
 )
 
-const (
-	defaultConnectTimeout = 15 * time.Second
-	defaultReadTimeout    = 60 * time.Second
-	defaultRequestTimeout = 6 * time.Second
-)
-
 type Config struct {
+	Enabled        bool            `yaml:"enabled"`
+	Clusters       []ConfigCluster `yaml:"clusters"`
 	ConnectTimeout time.Duration   `yaml:"connectTimeout"` // used for connectivity test
 	ReadTimeout    time.Duration   `yaml:"readTimeout"`    // overall REST/HTTP read timeout
 	RequestTimeout time.Duration   `yaml:"requestTimeout"` // timeout for REST requests to Kafka Connect
-	Enabled        bool            `yaml:"enabled"`
-	Clusters       []ConfigCluster `yaml:"clusters"`
 }
 
 func (c *Config) SetDefaults() {
 	for _, cluster := range c.Clusters {
 		cluster.SetDefaults()
 	}
-	c.ConnectTimeout = defaultConnectTimeout
-	c.ReadTimeout = defaultReadTimeout
-	c.RequestTimeout = defaultRequestTimeout
+	c.ConnectTimeout = 15 * time.Second
+	c.ReadTimeout = 50 * time.Second
+	c.RequestTimeout = 6 * time.Second
 }
 
 // RegisterFlags registers all nested config flags.

--- a/backend/pkg/connect/config.go
+++ b/backend/pkg/connect/config.go
@@ -28,7 +28,7 @@ func (c *Config) SetDefaults() {
 		cluster.SetDefaults()
 	}
 	c.ConnectTimeout = 15 * time.Second
-	c.ReadTimeout = 50 * time.Second
+	c.ReadTimeout = 60 * time.Second
 	c.RequestTimeout = 6 * time.Second
 }
 

--- a/backend/pkg/connect/service.go
+++ b/backend/pkg/connect/service.go
@@ -12,10 +12,10 @@ package connect
 import (
 	"context"
 	"crypto/tls"
-	"go.uber.org/zap"
 	"sync"
 	"sync/atomic"
-	"time"
+
+	"go.uber.org/zap"
 
 	con "github.com/cloudhut/connect-client"
 )
@@ -42,7 +42,7 @@ func NewService(cfg Config, logger *zap.Logger) (*Service, error) {
 			zap.String("cluster_name", clusterCfg.Name),
 			zap.String("cluster_address", clusterCfg.URL))
 
-		opts := []con.ClientOption{con.WithTimeout(60 * time.Second), con.WithUserAgent("Kowl")}
+		opts := []con.ClientOption{con.WithTimeout(cfg.ReadTimeout), con.WithUserAgent("Kowl")}
 
 		opts = append(opts, con.WithHost(clusterCfg.URL))
 		// TLS Config
@@ -77,7 +77,7 @@ func NewService(cfg Config, logger *zap.Logger) (*Service, error) {
 	}
 
 	// 2. Test connectivity against each cluster concurrently
-	shortCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	shortCtx, cancel := context.WithTimeout(context.Background(), cfg.ConnectTimeout)
 	defer cancel()
 	svc.TestConnectivity(shortCtx)
 

--- a/docs/config/kowl-business.yaml
+++ b/docs/config/kowl-business.yaml
@@ -128,6 +128,9 @@ kafka:
 #       username:
 #       password: # This can be set via the via the --connect.clusters.i.password flag as well (i to be replaced with the array index)
 #       token: # This can be set via the via the --connect.clusters.i.token flag as well (i to be replaced with the array index)
+#   connectTimeout: 15s # used to test cluster connectivity
+#   readTimeout: 60s    # overall REST timeout
+#   requestTimeout: 6s  # timeout for REST requests
 
 # owl:
 #   # Config to use for embedded topic documentation, see /docs/features/topic-documentation.md for more details

--- a/docs/config/kowl.yaml
+++ b/docs/config/kowl.yaml
@@ -128,6 +128,9 @@ kafka:
 #       username:
 #       password: # This can be set via the via the --connect.clusters.i.password flag as well (i to be replaced with the array index)
 #       token: # This can be set via the via the --connect.clusters.i.token flag as well (i to be replaced with the array index)
+#   connectTimeout: 15s # used to test cluster connectivity
+#   readTimeout: 60s    # overall REST timeout
+#   requestTimeout: 6s  # timeout for REST requests
 
 # owl:
 #   # Config to use for embedded topic documentation, see /docs/features/topic-documentation.md for more details


### PR DESCRIPTION
6 seconds is not enough when Kafka Connect has A LOT of connectors